### PR TITLE
Implement `IntoIterator` for `&Primes<N>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 This file contains the changes to the crate since version 0.4.8.
 
+# 0.5.1
+
+ - Implement `IntoIterator` for `&Primes<N>`.
+
 # 0.5.0
 
 This version focuses on adding support for generating primes and sieving numbers in arbitrary ranges, instead of always having to start from 0.  

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "const-primes"
 authors = ["Johanna Sörngård (jsorngard@gmail.com)"]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["primes", "const"]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -366,6 +366,8 @@ impl<const N: usize> AsRef<[Underlying; N]> for Primes<N> {
 
 // endregion: AsRef
 
+// region: IntoIterator
+
 impl<const N: usize> IntoIterator for Primes<N> {
     type Item = <[Underlying; N] as IntoIterator>::Item;
     type IntoIter = <[Underlying; N] as IntoIterator>::IntoIter;
@@ -382,6 +384,8 @@ impl<'a, const N: usize> IntoIterator for &'a Primes<N> {
         self.primes.iter()
     }
 }
+
+// endregion: IntoIterator
 
 // region: PartialEq
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -375,6 +375,14 @@ impl<const N: usize> IntoIterator for Primes<N> {
     }
 }
 
+impl<'a, const N: usize> IntoIterator for &'a Primes<N> {
+    type IntoIter = <&'a [Underlying; N] as IntoIterator>::IntoIter;
+    type Item = <&'a [Underlying; N] as IntoIterator>::Item;
+    fn into_iter(self) -> Self::IntoIter {
+        self.primes.iter()
+    }
+}
+
 // region: PartialEq
 
 impl<const N: usize, T: PartialEq<[Underlying; N]>> PartialEq<T> for Primes<N> {


### PR DESCRIPTION
Implements a non-owning `IntoIterator` for a reference to a `Primes<N>`.