### PR TITLE
Convert all panics to const assertions for when 1.79.0 lands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 This file contains the changes to the crate since version 0.4.8.
 
+# 0.7.0
+
+ - Change all panics that only involve const generics into const assertions that fail at compile time.
+ - Update MSRV to 1.79.0
+
 # 0.6.2
 
- - Minor documentation tweaks.
+ - Minor documentation tweaks
 
 # 0.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 This file contains the changes to the crate since version 0.4.8.
 
-# 0.7.0
+# 0.8.0
 
  - Change all panics that only involve const generics into const assertions that fail at compile time.
  - Update MSRV to 1.79.0.
+
+# 0.7.0
+
+## Breaking changes
+
+  - Remove the `N` const generic from `PrimesIter` as it doesn't use it.
 
 # 0.6.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@ This file contains the changes to the crate since version 0.4.8.
 
 # 0.8.0
 
+## Breaking changes
+
  - Change all panics that only involve const generics into const assertions that fail at compile time.
- - Update MSRV to 1.79.0.
+ - Update information about minimum supported version to 1.79.0.
 
 # 0.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@ This file contains the changes to the crate since version 0.4.8.
 # 0.7.0
 
  - Change all panics that only involve const generics into const assertions that fail at compile time.
- - Update MSRV to 1.79.0
+ - Update MSRV to 1.79.0.
 
 # 0.6.2
 
- - Minor documentation tweaks
+ - Minor documentation tweaks.
 
 # 0.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 This file contains the changes to the crate since version 0.4.8.
 
+# 0.6.0
+
+ - Changed all panics that involve only const generics into compile errors.
+
 # 0.5.1
 
  - Implement `IntoIterator` for `&Primes<N>`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "const-primes"
 authors = ["Johanna Sörngård (jsorngard@gmail.com)"]
-version = "0.6.2"
+version = "0.8.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["const", "primes"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "const-primes"
 authors = ["Johanna Sörngård (jsorngard@gmail.com)"]
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["primes", "const"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A crate for generating and working with prime numbers in const contexts.
 
-`#![no_std]` compatible, and currently supports Rust versions 1.68.2 and newer.
+`#![no_std]` compatible, and currently supports Rust versions 1.79.0 or newer.
 
 ## Examples
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -40,6 +40,8 @@ pub struct Primes<const N: usize> {
 impl<const N: usize> Primes<N> {
     /// Generates a new instance that contains the first `N` primes.
     ///
+    /// Fails to compile if `N` is 0.
+    ///
     /// Uses a [segmented sieve of Eratosthenes](https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes#Segmented_sieve).
     ///
     /// # Examples
@@ -61,19 +63,11 @@ impl<const N: usize> Primes<N> {
     /// let primes = Primes::<5>::new();
     /// assert_eq!(primes, [2, 3, 5, 7, 11]);
     /// ```
-    ///
-    /// # Panics
-    ///
-    /// Panics if `N` is zero. In const contexts this is a compile error.
-    /// ```compile_fail
-    /// # use const_primes::Primes;
-    /// const NO_PRIMES: Primes<0> = Primes::new();
-    /// ```
-    ///
-    /// If any of the primes overflow a `u32` it will panic in const contexts or debug mode.
     #[must_use = "the associated method only returns a new value"]
     pub const fn new() -> Self {
-        assert!(N > 0, "`N` must be at least 1");
+        const {
+            assert!(N > 0, "`N` must be at least 1");
+        }
         Self { primes: primes() }
     }
 
@@ -300,7 +294,7 @@ impl<const N: usize> Primes<N> {
     pub const fn last(&self) -> &Underlying {
         match self.primes.last() {
             Some(l) => l,
-            None => panic!("this should panic during creation"),
+            None => panic!("creating an empty `Primes` fails to compile"),
         }
     }
 
@@ -322,10 +316,12 @@ impl<const N: usize> Primes<N> {
     }
 }
 
-/// Panics if `N` is 0.
+/// Fails to compile if `N` is 0.
 impl<const N: usize> Default for Primes<N> {
     fn default() -> Self {
-        assert!(N > 0, "`N` must be at least 1");
+        const {
+            assert!(N > 0, "`N` must be at least 1");
+        }
         Self { primes: primes() }
     }
 }

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -243,10 +243,10 @@ pub const fn primes_lt<const N: usize, const MEM: usize>(
 /// assert_eq!(PRIMES_LT, Ok([4999999903, 4999999937, 5000000029]));
 /// ```
 ///
-/// # Errors and panics
+/// # Errors
 ///
-/// Has the same error and panic behaviour as [`primes_geq`] and [`primes_lt`], with the exception
-/// that it sets `MEM` such that the functions don't panic or run out of memory.
+/// Has the same error behaviour as [`primes_geq`] and [`primes_lt`], with the exception
+/// that it sets `MEM` such that the functions don't run out of memory.
 #[macro_export]
 macro_rules! primes_segment {
     ($n:expr; < $lim:expr) => {

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -10,6 +10,8 @@ use crate::{sieve, sieve::sieve_segment, Underlying};
 ///
 /// Uses a [segmented sieve of Eratosthenes](https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes#Segmented_sieve).
 ///
+/// Fails to compile if `N` is 0.
+///
 /// # Example
 ///
 /// ```
@@ -17,18 +19,11 @@ use crate::{sieve, sieve::sieve_segment, Underlying};
 /// const PRIMES: [u32; 10] = primes();
 /// assert_eq!(PRIMES, [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]);
 /// ```
-///
-/// # Panics
-///
-/// Panics if `N` is 0. In const contexts this is a compile error:
-/// ```compile_fail
-/// # use const_primes::primes;
-/// const PRIMES: [u32; 0] = primes();
-/// ```
-///
 #[must_use = "the function only returns a new value"]
 pub const fn primes<const N: usize>() -> [Underlying; N] {
-    assert!(N > 0, "`N` must be at least 1");
+    const {
+        assert!(N > 0, "`N` must be at least 1");
+    }
 
     if N == 1 {
         return [2; N];

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -19,7 +19,6 @@ use crate::{sieve, sieve::sieve_segment, Underlying};
 /// ```
 #[must_use = "the function only returns a new value"]
 pub const fn primes<const N: usize>() -> [Underlying; N] {
-
     if N <= 1 {
         return [2; N];
     } else if N == 2 {
@@ -181,7 +180,7 @@ pub const fn primes_lt<const N: usize, const MEM: usize>(
     }
 
     let mut primes: [u64; N] = [0; N];
-  
+
     if N == 0 {
         return Ok(primes);
     }
@@ -327,7 +326,7 @@ pub const fn primes_geq<const N: usize, const MEM: usize>(
     const {
         assert!(MEM >= N, "`MEM` must be at least as large as `N`");
     }
-  
+
     let (mem64, mem_sqr) = const {
         let mem64 = MEM as u64;
         match mem64.checked_mul(mem64) {
@@ -339,7 +338,7 @@ pub const fn primes_geq<const N: usize, const MEM: usize>(
     if N == 0 {
         return Ok([0; N]);
     }
-  
+
     // If `lower_limit` is 2 or less, this is the same as calling `primes`,
     // so we just do that and convert the result to `u64`.
     if lower_limit <= 2 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! A crate for generating and working with prime numbers in const contexts.
 //!
-//! `#![no_std]` compatible, and currently supports Rust versions 1.68.2 or newer.
+//! `#![no_std]` compatible, and currently supports Rust versions 1.79.0 or newer.
 //!
 //! # Examples
 //!

--- a/src/sieve.rs
+++ b/src/sieve.rs
@@ -12,7 +12,6 @@ pub(crate) const fn sieve_segment<const N: usize>(
     base_sieve: &[bool; N],
     upper_limit: u64,
 ) -> [bool; N] {
-
     let mut segment_sieve = [true; N];
 
     let lower_limit = upper_limit - N as u64;
@@ -137,7 +136,7 @@ pub const fn sieve_lt<const N: usize, const MEM: usize>(
     if upper_limit < n64 {
         return Err(SieveError::TooSmallLimit);
     }
-  
+
     if N == 0 {
         return Ok([false; N]);
     }
@@ -174,7 +173,6 @@ pub const fn sieve_lt<const N: usize, const MEM: usize>(
 /// ```
 #[must_use = "the function only returns a new value"]
 pub const fn sieve<const N: usize>() -> [bool; N] {
-
     let mut sieve = [true; N];
     if N == 0 {
         return sieve;
@@ -312,7 +310,7 @@ pub const fn sieve_geq<const N: usize, const MEM: usize>(
     if upper_limit > mem_sqr {
         return Err(SieveError::TooSmallSieveSize);
     }
-  
+
     if N == 0 {
         return Ok([false; N]);
     }

--- a/src/sieve.rs
+++ b/src/sieve.rs
@@ -164,6 +164,8 @@ pub const fn sieve_lt<const N: usize, const MEM: usize>(
 
 /// Returns an array of size `N` where the value at a given index indicates whether the index is prime.
 ///
+/// Fails to compile if `N` is 0.
+///
 /// # Example
 ///
 /// ```
@@ -172,17 +174,11 @@ pub const fn sieve_lt<const N: usize, const MEM: usize>(
 /// //                     0      1      2     3     4      5     6      7     8      9
 /// assert_eq!(PRIMALITY, [false, false, true, true, false, true, false, true, false, false]);
 /// ```
-///
-/// # Panics
-///
-/// Panics if `N` is 0. In const contexts this is a compile error:
-/// ```compile_fail
-/// # use const_primes::sieve;
-/// const PRIMALITY: [bool; 0] = sieve();
-/// ```
 #[must_use = "the function only returns a new value"]
 pub const fn sieve<const N: usize>() -> [bool; N] {
-    assert!(N > 0, "`N` must be at least 1");
+    const {
+        assert!(N > 0, "`N` must be at least 1");
+    }
 
     let mut sieve = [true; N];
     if N > 0 {

--- a/src/sieve.rs
+++ b/src/sieve.rs
@@ -248,7 +248,7 @@ impl std::error::Error for SieveError {}
 /// that is `MEM`^2 must be larger than `lower_limit + N`.
 ///
 /// Fails to compile if `N` is 0, if `MEM` is smaller than `N`, or if `MEM`^2 does not fit in a `u64`.
-/// 
+///
 /// If you just want the prime status of the first N integers, see [`sieve`], and if you want the
 /// prime status of the integers below some number, see [`sieve_lt`].
 ///

--- a/src/sieve.rs
+++ b/src/sieve.rs
@@ -7,16 +7,14 @@ use crate::isqrt;
 /// Uses the primalities of the first `N` integers in `base_sieve` to sieve the numbers in the range `[upper_limit - N, upper_limit)`.
 /// Assumes that the base sieve contains the prime status of the `N` fist integers. The output is only meaningful
 /// for the numbers below `N^2`. Fails to compile if `N` is 0.
-///
-/// # Panics
-///
-/// Panics if `N` is 0.
 #[must_use = "the function only returns a new value and does not modify its inputs"]
 pub(crate) const fn sieve_segment<const N: usize>(
     base_sieve: &[bool; N],
     upper_limit: u64,
 ) -> [bool; N] {
-    assert!(N > 0, "`N` must be at least 1");
+    const {
+        assert!(N > 0, "`N` must be at least 1");
+    }
 
     let mut segment_sieve = [true; N];
 
@@ -62,6 +60,8 @@ pub(crate) const fn sieve_segment<const N: usize>(
 /// Uses a sieve of size `MEM` during evaluation, but stores only the requested values in the output array.
 /// `MEM` must be large enough for the sieve to be able to determine the prime status of all numbers in the requested range,
 /// that is: `MEM`^2 must be at least as large as `upper_limit`.
+///
+/// Fails to compile if `N` is 0, if `MEM` is smaller than `N`, or if `MEM`^2 does not fit in a `u64`.
 ///
 /// If you just want the prime status of the first `N` integers, see [`sieve`], and if you want the prime status of
 /// the integers above some number, see [`sieve_geq`].
@@ -116,22 +116,20 @@ pub(crate) const fn sieve_segment<const N: usize>(
 /// const PS: Result<[bool; 5], SieveError> = sieve_lt::<5, 5>(4);
 /// assert_eq!(PS, Err(SieveError::TooSmallLimit));
 /// ```
-///
-/// # Panics
-///
-/// Panics if `N` is 0, if `MEM` is smaller than `N`, or if `MEM`^2 does not fit in a `u64`.
-/// In const contexts this is a compile error.
 #[must_use = "the function only returns a new value and does not modify its input"]
 pub const fn sieve_lt<const N: usize, const MEM: usize>(
     upper_limit: u64,
 ) -> Result<[bool; N], SieveError> {
-    assert!(N > 0, "`N` must be at least 1");
-    assert!(MEM >= N, "`MEM` must be at least as large as `N`");
-
-    let mem64 = MEM as u64;
-
-    let Some(mem_sqr) = mem64.checked_mul(mem64) else {
-        panic!("`MEM`^2 must fit in a `u64`");
+    const {
+        assert!(N > 0, "`N` must be at least 1");
+        assert!(MEM >= N, "`MEM` must be at least as large as `N`");
+    }
+    let mem_sqr = const {
+        let mem64 = MEM as u64;
+        match mem64.checked_mul(mem64) {
+            Some(mem_sqr) => mem_sqr,
+            None => panic!("`MEM`^2 must fit in a `u64`"),
+        }
     };
 
     if upper_limit > mem_sqr {


### PR DESCRIPTION
This PR changes all panics into static assertions instead. This needs rust version 1.79.0 (current beta) to compile.