### PR TITLE
Make the `Primes<N>::iter` function and the `IntoIterator` implementation for `Primes<N>` return custom types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "const-primes"
 authors = ["Johanna Sörngård (jsorngard@gmail.com)"]
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["primes", "const"]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -209,6 +209,7 @@ impl<const N: usize> Primes<N> {
     /// Basic usage:
     /// ```
     /// # use const_primes::Primes;
+    /// // [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
     /// const PRIMES: Primes<10> = Primes::new();
     ///
     /// type SearchResult = Result<usize, Option<usize>>;

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -210,9 +210,12 @@ impl<const N: usize> Primes<N> {
     /// ```
     /// # use const_primes::Primes;
     /// const PRIMES: Primes<10> = Primes::new();
-    /// const WHERE_29: Result<usize, Option<usize>> = PRIMES.binary_search(29);
-    /// const WHERE_6: Result<usize, Option<usize>> = PRIMES.binary_search(6);
-    /// const WHERE_1000: Result<usize, Option<usize>> = PRIMES.binary_search(1_000);
+    ///
+    /// type SearchResult = Result<usize, Option<usize>>;
+    ///
+    /// const WHERE_29: SearchResult = PRIMES.binary_search(29);
+    /// const WHERE_6: SearchResult = PRIMES.binary_search(6);
+    /// const WHERE_1000: SearchResult = PRIMES.binary_search(1_000);
     ///
     /// assert_eq!(WHERE_29, Ok(9));
     /// assert_eq!(WHERE_6, Err(Some(3)));

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -203,6 +203,21 @@ impl<const N: usize> Primes<N> {
     /// variant is returned and contains the index of that location.
     /// If the target is larger than the largest prime in the array no information about where it might fit is available,
     /// and an [`Option::None`] is returned.
+    ///
+    /// # Example
+    ///
+    /// Basic usage:
+    /// ```
+    /// # use const_primes::Primes;
+    /// const PRIMES: Primes<10> = Primes::new();
+    /// const WHERE_29: Result<usize, Option<usize>> = PRIMES.binary_search(29);
+    /// const WHERE_6: Result<usize, Option<usize>> = PRIMES.binary_search(6);
+    /// const WHERE_1000: Result<usize, Option<usize>> = PRIMES.binary_search(1_000);
+    ///
+    /// assert_eq!(WHERE_29, Ok(9));
+    /// assert_eq!(WHERE_6, Err(Some(3)));
+    /// assert_eq!(WHERE_1000, Err(None));
+    /// ```
     #[must_use = "the method only returns a new value and does not modify `self`"]
     pub const fn binary_search(&self, target: Underlying) -> Result<usize, Option<usize>> {
         if target > *self.last() {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -197,6 +197,7 @@ impl<const N: usize> Primes<N> {
     // endregion: Next prime
 
     /// Searches the underlying array of primes for the target integer.
+    ///
     /// If the target is found it returns a [`Result::Ok`] that contains the index of the matching element.
     /// If the target is not found in the array a [`Result::Err`] is returned that contains an [`Option`].   
     /// If the target could be inserted into the array while maintaining the sorted order, the [`Option::Some`]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -272,6 +272,7 @@ impl<const N: usize> Primes<N> {
     ///
     /// assert_eq!(primes.nth(5), Some(&13));
     /// assert_eq!(primes.next(), Some(&17));
+    /// assert_eq!(primes.as_slice(), &[19, 23, 29]);
     /// ```
     #[inline]
     pub fn iter(&self) -> PrimesIter<'_, N> {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -267,9 +267,9 @@ impl<const N: usize> Primes<N> {
     /// ```
     /// # use const_primes::Primes;
     /// const PRIMES: Primes<10> = Primes::new();
-    /// 
+    ///
     /// let mut primes = PRIMES.iter();
-    /// 
+    ///
     /// assert_eq!(primes.nth(5), Some(&13));
     /// assert_eq!(primes.next(), Some(&17));
     /// ```
@@ -407,6 +407,11 @@ mod primes_iter {
         pub(crate) const fn new(iter: core::slice::Iter<'a, Underlying>) -> Self {
             Self(iter)
         }
+
+        /// Returns an immutable slice of all the primes that have not been yielded yet.
+        pub fn as_slice(&self) -> &[Underlying] {
+            self.0.as_slice()
+        }
     }
 
     impl<'a, const N: usize> Iterator for PrimesIter<'a, N> {
@@ -474,6 +479,11 @@ mod primes_into_iter {
     impl<const N: usize> PrimesIntoIter<N> {
         pub(crate) const fn new(iter: core::array::IntoIter<Underlying, N>) -> Self {
             Self(iter)
+        }
+
+        /// Returns an immutable slice of all primes that have not been yielded yet.
+        pub fn as_slice(&self) -> &[Underlying] {
+            self.0.as_slice()
         }
     }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -259,7 +259,20 @@ impl<const N: usize> Primes<N> {
         self.primes.as_slice()
     }
 
-    /// Returns an iterator over the primes.
+    /// Returns a borrowing iterator over the primes.
+    ///
+    /// # Example
+    ///
+    /// Basic usage:
+    /// ```
+    /// # use const_primes::Primes;
+    /// const PRIMES: Primes<10> = Primes::new();
+    /// 
+    /// let mut primes = PRIMES.iter();
+    /// 
+    /// assert_eq!(primes.nth(5), Some(&13));
+    /// assert_eq!(primes.next(), Some(&17));
+    /// ```
     #[inline]
     pub fn iter(&self) -> PrimesIter<'_, N> {
         PrimesIter::new(IntoIterator::into_iter(&self.primes))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@
 // This is used since there is currently no way to be generic over types that can do arithmetic at compile time.
 type Underlying = u32;
 
-mod cache;
+pub mod cache;
 mod check;
 mod count;
 mod generate;


### PR DESCRIPTION
This enables the modification of these internals in the future without it being a breaking change.