### PR TITLE
Remove panics when `N` is 0 for functions (but not for `Primes<N>`)

### DIFF
--- a/src/count.rs
+++ b/src/count.rs
@@ -12,13 +12,8 @@ use crate::sieve;
 /// const COUNTS: [usize; 10] = count_primes();
 /// assert_eq!(COUNTS, [0, 0, 1, 2, 2, 3, 3, 4, 4, 4]);
 /// ```
-///
-/// # Panics
-///
-/// Panics if `N` is 0. In const contexts this is a compile error.
 #[must_use = "the function only returns a new value"]
 pub const fn count_primes<const N: usize>() -> [usize; N] {
-    assert!(N > 0, "`N` must be at least 1");
     let mut counts = [0; N];
     if N <= 2 {
         return counts;

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -17,20 +17,9 @@ use crate::{sieve, sieve::sieve_segment, Underlying};
 /// const PRIMES: [u32; 10] = primes();
 /// assert_eq!(PRIMES, [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]);
 /// ```
-///
-/// # Panics
-///
-/// Panics if `N` is 0. In const contexts this is a compile error:
-/// ```compile_fail
-/// # use const_primes::primes;
-/// const PRIMES: [u32; 0] = primes();
-/// ```
-///
 #[must_use = "the function only returns a new value"]
 pub const fn primes<const N: usize>() -> [Underlying; N] {
-    assert!(N > 0, "`N` must be at least 1");
-
-    if N == 1 {
+    if N <= 1 {
         return [2; N];
     } else if N == 2 {
         let mut primes = [0; N];
@@ -167,12 +156,11 @@ pub const fn primes<const N: usize>() -> [Underlying; N] {
 ///
 /// # Panics
 ///
-/// Panics if `N` or `MEM` are 0, if `MEM < N` or if `MEM`^2 does not fit in a `u64`.
+/// Panics if `MEM` is smaller than `N` or if `MEM`^2 does not fit in a `u64`.
 #[must_use = "the function only returns a new value and does not modify its input"]
 pub const fn primes_lt<const N: usize, const MEM: usize>(
     mut upper_limit: u64,
 ) -> Result<[u64; N], GenerationError> {
-    assert!(N > 0, "`N` must be at least 1");
     assert!(MEM >= N, "`MEM` must be at least as large as `N`");
 
     let mem64 = MEM as u64;
@@ -326,12 +314,11 @@ macro_rules! primes_segment {
 ///
 /// # Panics
 ///
-/// Panics if `N` or `MEM` are 0, if `MEM` is smaller than `N`, or if `MEM`^2 does not fit in a `u64`.
+/// Panics if `MEM` is smaller than `N`, or if `MEM`^2 does not fit in a `u64`.
 #[must_use = "the function only returns a new value and does not modify its input"]
 pub const fn primes_geq<const N: usize, const MEM: usize>(
     lower_limit: u64,
 ) -> Result<[u64; N], GenerationError> {
-    assert!(N > 0, "`N` must be at least 1");
     assert!(MEM >= N, "`MEM` must be at least as large as `N`");
 
     let mem64 = MEM as u64;

--- a/src/sieve.rs
+++ b/src/sieve.rs
@@ -7,17 +7,11 @@ use crate::isqrt;
 /// Uses the primalities of the first `N` integers in `base_sieve` to sieve the numbers in the range `[upper_limit - N, upper_limit)`.
 /// Assumes that the base sieve contains the prime status of the `N` fist integers. The output is only meaningful
 /// for the numbers below `N^2`. Fails to compile if `N` is 0.
-///
-/// # Panics
-///
-/// Panics if `N` is 0.
 #[must_use = "the function only returns a new value and does not modify its inputs"]
 pub(crate) const fn sieve_segment<const N: usize>(
     base_sieve: &[bool; N],
     upper_limit: u64,
 ) -> [bool; N] {
-    assert!(N > 0, "`N` must be at least 1");
-
     let mut segment_sieve = [true; N];
 
     let lower_limit = upper_limit - N as u64;
@@ -119,13 +113,12 @@ pub(crate) const fn sieve_segment<const N: usize>(
 ///
 /// # Panics
 ///
-/// Panics if `N` is 0, if `MEM` is smaller than `N`, or if `MEM`^2 does not fit in a `u64`.
+/// Panics if `MEM` is smaller than `N`, or if `MEM`^2 does not fit in a `u64`.
 /// In const contexts this is a compile error.
 #[must_use = "the function only returns a new value and does not modify its input"]
 pub const fn sieve_lt<const N: usize, const MEM: usize>(
     upper_limit: u64,
 ) -> Result<[bool; N], SieveError> {
-    assert!(N > 0, "`N` must be at least 1");
     assert!(MEM >= N, "`MEM` must be at least as large as `N`");
 
     let mem64 = MEM as u64;
@@ -174,18 +167,8 @@ pub const fn sieve_lt<const N: usize, const MEM: usize>(
 /// //                     0      1      2     3     4      5     6      7     8      9
 /// assert_eq!(PRIMALITY, [false, false, true, true, false, true, false, true, false, false]);
 /// ```
-///
-/// # Panics
-///
-/// Panics if `N` is 0. In const contexts this is a compile error:
-/// ```compile_fail
-/// # use const_primes::sieve;
-/// const PRIMALITY: [bool; 0] = sieve();
-/// ```
 #[must_use = "the function only returns a new value"]
 pub const fn sieve<const N: usize>() -> [bool; N] {
-    assert!(N > 0, "`N` must be at least 1");
-
     let mut sieve = [true; N];
     if N > 0 {
         sieve[0] = false;
@@ -298,13 +281,12 @@ impl std::error::Error for SieveError {}
 ///
 /// # Panics
 ///
-/// Panics if `N` is 0, if `MEM` is smaller than `N`, or if `MEM`^2 does not fit in a `u64`.
+/// Panics if `MEM` is smaller than `N`, or if `MEM`^2 does not fit in a `u64`.
 /// In const contexts this is a compile error.
 #[must_use = "the function only returns a new value and does not modify its input"]
 pub const fn sieve_geq<const N: usize, const MEM: usize>(
     lower_limit: u64,
 ) -> Result<[bool; N], SieveError> {
-    assert!(N > 0, "`N` must be at least 1");
     assert!(MEM >= N, "`MEM` must be at least as large as `N`");
 
     let mem64 = MEM as u64;


### PR DESCRIPTION
The functions don't actually have to panic then. The result may be useless, but it could be what the user wants.