### PR TITLE
Add `Primes<N>::prime_factorization` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ This file contains the changes to the crate since version 0.4.8.
 
 # 0.7.2
 
- - Add `Primes<N>::factorize` function that returns an iterator over the prime factors of the given number.
+ - Add `Primes<N>::prime_factorization` function that returns an iterator over the prime factors of the given number and their multiplicities.
 
 # 0.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 This file contains the changes to the crate since version 0.4.8.
 
+# 0.7.2
+
+ - Add `Primes<N>::factorize` function that returns an iterator over the prime factors of the given number.
+
 # 0.7.1
 
  - Organize the examples in the readme and top level crate documentation in a clearer way.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "const-primes"
 authors = ["Johanna Sörngård <jsorngard@gmail.com>"]
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["const", "primes"]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -146,16 +146,16 @@ impl<const N: usize> Primes<N> {
     /// # use const_primes::Primes;
     /// const CACHE: Primes<3> = Primes::new();
     ///
-    /// assert_eq!(CACHE.factorize(15).collect::<Vec<_>>(), &[(3, 1), (5, 1)]);
-    /// assert_eq!(CACHE.factorize(9).collect::<Vec<_>>(), &[(3, 2)]);
+    /// assert_eq!(CACHE.prime_factorization(15).collect::<Vec<_>>(), &[(3, 1), (5, 1)]);
+    /// assert_eq!(CACHE.prime_factorization(9).collect::<Vec<_>>(), &[(3, 2)]);
     ///
     /// // 14 is 2*7, but 7 is not in the cache, so the iterator only returns the 2:
-    /// let mut factorization_of_14 = CACHE.factorize(14);
+    /// let mut factorization_of_14 = CACHE.prime_factorization(14);
     /// assert_eq!(factorization_of_14.next(), Some((2, 1)));
     /// // the factor of 7 can be found with the remainder function:
     /// assert_eq!(factorization_of_14.remainder(), Some(7));
     /// ```
-    pub fn factorize(&self, number: Underlying) -> PrimeFactors<'_> {
+    pub fn prime_factorization(&self, number: Underlying) -> PrimeFactors<'_> {
         PrimeFactors::new(&self.primes, number)
     }
 
@@ -434,7 +434,7 @@ mod prime_factors {
     use core::iter::FusedIterator;
 
     /// An iterator over the prime factors of a number and their multiplicities.
-    /// Created by the [`factorize`](super::Primes::factorize) function on [`Primes`](super::Primes),
+    /// Created by the [`prime_factorization`](super::Primes::prime_factorization) function on [`Primes`](super::Primes),
     /// see it for more information.
     #[derive(Debug, Clone, Copy)]
     pub struct PrimeFactors<'a> {
@@ -806,6 +806,27 @@ mod test {
         assert_eq!(PREV400, Some(397));
         assert_eq!(PREV541, Some(523));
         assert_eq!(PREV542, None);
+    }
+
+    #[test]
+    fn check_prime_factorization() {
+        const CACHE: Primes<3> = Primes::new();
+
+        let mut factorization_of_14 = CACHE.prime_factorization(14);
+
+        assert_eq!(factorization_of_14.next(), Some((2, 1)));
+        assert_eq!(factorization_of_14.next(), None);
+        assert_eq!(factorization_of_14.remainder(), Some(7));
+        assert_eq!(
+            CACHE.prime_factorization(15).collect::<Vec<_>>(),
+            &[(3, 1), (5, 1)]
+        );
+        assert_eq!(
+            CACHE
+                .prime_factorization(2 * 3 * 3 * 3 * 5)
+                .collect::<Vec<_>>(),
+            &[(2, 1), (3, 3), (5, 1)]
+        );
     }
 
     #[test]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -149,11 +149,11 @@ impl<const N: usize> Primes<N> {
     /// assert_eq!(CACHE.prime_factorization(15).collect::<Vec<_>>(), &[(3, 1), (5, 1)]);
     /// assert_eq!(CACHE.prime_factorization(9).collect::<Vec<_>>(), &[(3, 2)]);
     ///
-    /// // 14 is 2*7, but 7 is not in the cache, so the iterator only returns the 2:
-    /// let mut factorization_of_14 = CACHE.prime_factorization(14);
-    /// assert_eq!(factorization_of_14.next(), Some((2, 1)));
+    /// // 42 is 2*3*7, but seven is not in the cache, so the iterator only returns the twos:
+    /// let mut factorization_of_42 = CACHE.prime_factorization(42);
+    /// assert_eq!(factorization_of_42.by_ref().collect::<Vec<_>>(), &[(2, 1), (3, 1)]);
     /// // the factor of 7 can be found with the remainder function:
-    /// assert_eq!(factorization_of_14.remainder(), Some(7));
+    /// assert_eq!(factorization_of_42.remainder(), Some(7));
     /// ```
     pub fn prime_factorization(&self, number: Underlying) -> PrimeFactorization<'_> {
         PrimeFactorization::new(&self.primes, number)
@@ -436,7 +436,7 @@ mod prime_factors {
     /// An iterator over the prime factors of a number and their multiplicities.
     /// Created by the [`prime_factorization`](super::Primes::prime_factorization) function on [`Primes`](super::Primes),
     /// see it for more information.
-    #[derive(Debug, Clone, Copy)]
+    #[derive(Debug, Clone)]
     pub struct PrimeFactorization<'a> {
         primes_cache: &'a [Underlying],
         cache_index: usize,
@@ -817,10 +817,15 @@ mod test {
         assert_eq!(factorization_of_14.next(), Some((2, 1)));
         assert_eq!(factorization_of_14.next(), None);
         assert_eq!(factorization_of_14.remainder(), Some(7));
+
+        let mut factorization_of_15 = CACHE.prime_factorization(15);
+
         assert_eq!(
-            CACHE.prime_factorization(15).collect::<Vec<_>>(),
+            factorization_of_15.by_ref().collect::<Vec<_>>(),
             &[(3, 1), (5, 1)]
         );
+        assert!(factorization_of_15.remainder().is_none());
+
         assert_eq!(
             CACHE
                 .prime_factorization(2 * 3 * 3 * 3 * 5)

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -467,22 +467,20 @@ mod prime_factors {
     impl<'a> Iterator for PrimeFactors<'a> {
         type Item = (Underlying, u8);
         fn next(&mut self) -> Option<Self::Item> {
-            if let Some(prime) = self.primes_cache.get(self.cache_index) {
+            while let Some(prime) = self.primes_cache.get(self.cache_index) {
                 let mut count = 0;
                 while self.number % prime == 0 {
                     count += 1;
                     self.number /= prime;
                 }
+
                 self.cache_index += 1;
-                if count == 0 {
-                    // This prime was not a factor, check the next one
-                    self.next()
-                } else {
-                    Some((*prime, count))
+
+                if count > 0 {
+                    return Some((*prime, count));
                 }
-            } else {
-                None
             }
+            None
         }
     }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -149,7 +149,7 @@ impl<const N: usize> Primes<N> {
     /// assert_eq!(CACHE.prime_factorization(15).collect::<Vec<_>>(), &[(3, 1), (5, 1)]);
     /// assert_eq!(CACHE.prime_factorization(9).collect::<Vec<_>>(), &[(3, 2)]);
     ///
-    /// // 42 is 2*3*7, but seven is not in the cache, so the iterator only returns the twos:
+    /// // 42 is 2*3*7, but seven is not in the cache, so the iterator only returns the two and three:
     /// let mut factorization_of_42 = CACHE.prime_factorization(42);
     /// assert_eq!(factorization_of_42.by_ref().collect::<Vec<_>>(), &[(2, 1), (3, 1)]);
     /// // the factor of 7 can be found with the remainder function:

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -151,7 +151,9 @@ impl<const N: usize> Primes<N> {
     ///
     /// // 42 is 2*3*7, but seven is not in the cache, so the iterator only returns the two and three:
     /// let mut factorization_of_42 = CACHE.prime_factorization(42);
+    ///
     /// assert_eq!(factorization_of_42.by_ref().collect::<Vec<_>>(), &[(2, 1), (3, 1)]);
+    ///
     /// // the factor of 7 can be found with the remainder function:
     /// assert_eq!(factorization_of_42.remainder(), Some(7));
     /// ```

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -155,7 +155,7 @@ impl<const N: usize> Primes<N> {
     /// // the factor of 7 can be found with the remainder function:
     /// assert_eq!(factorization_of_14.remainder(), Some(7));
     /// ```
-    pub const fn factorize(&self, number: Underlying) -> PrimeFactors<'_> {
+    pub fn factorize(&self, number: Underlying) -> PrimeFactors<'_> {
         PrimeFactors::new(&self.primes, number)
     }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -155,8 +155,8 @@ impl<const N: usize> Primes<N> {
     /// // the factor of 7 can be found with the remainder function:
     /// assert_eq!(factorization_of_14.remainder(), Some(7));
     /// ```
-    pub fn prime_factorization(&self, number: Underlying) -> PrimeFactors<'_> {
-        PrimeFactors::new(&self.primes, number)
+    pub fn prime_factorization(&self, number: Underlying) -> PrimeFactorization<'_> {
+        PrimeFactorization::new(&self.primes, number)
     }
 
     // region: Next prime
@@ -427,7 +427,7 @@ impl<const N: usize> AsRef<[Underlying; N]> for Primes<N> {
 
 // endregion: AsRef
 
-pub use prime_factors::PrimeFactors;
+pub use prime_factors::PrimeFactorization;
 mod prime_factors {
     use super::Underlying;
 
@@ -437,13 +437,13 @@ mod prime_factors {
     /// Created by the [`prime_factorization`](super::Primes::prime_factorization) function on [`Primes`](super::Primes),
     /// see it for more information.
     #[derive(Debug, Clone, Copy)]
-    pub struct PrimeFactors<'a> {
+    pub struct PrimeFactorization<'a> {
         primes_cache: &'a [Underlying],
         cache_index: usize,
         number: Underlying,
     }
 
-    impl<'a> PrimeFactors<'a> {
+    impl<'a> PrimeFactorization<'a> {
         pub(crate) const fn new(primes_cache: &'a [Underlying], number: Underlying) -> Self {
             Self {
                 primes_cache,
@@ -464,7 +464,7 @@ mod prime_factors {
         }
     }
 
-    impl<'a> Iterator for PrimeFactors<'a> {
+    impl<'a> Iterator for PrimeFactorization<'a> {
         type Item = (Underlying, u8);
         fn next(&mut self) -> Option<Self::Item> {
             while let Some(prime) = self.primes_cache.get(self.cache_index) {
@@ -484,7 +484,7 @@ mod prime_factors {
         }
     }
 
-    impl<'a> FusedIterator for PrimeFactors<'a> {}
+    impl<'a> FusedIterator for PrimeFactorization<'a> {}
 }
 
 // region: IntoIterator


### PR DESCRIPTION
This PR adds a function to `Primes<N>` that returns an iterator over all prime factors of a given number and their multiplicities.

Since a `Primes<N>` only contains `N` primes it's not possible to extract factors larger than the `N`th prime, so an additional function on the iterator can be used to get this remaining part.