### PR TITLE
Add `prime_factors` function to `Primes<N>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 This file contains the changes to the crate since version 0.4.8.
 
+# 0.7.3
+
+ - Add `Primes<N>::prime_factors` function that returns an iterator over the prime factors of the given number.
+
 # 0.7.2
 
  - Add `Primes<N>::prime_factorization` function that returns an iterator over the prime factors of the given number and their multiplicities.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ This file contains the changes to the crate since version 0.4.8.
 
 # 0.7.3
 
- - Add `Primes<N>::prime_factors` function that returns an iterator over the prime factors of the given number.
+ - Add `Primes<N>::prime_factors` function that returns an iterator over the prime factors of the given number (and not their multiplicities).
 
 # 0.7.2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "const-primes"
 authors = ["Johanna Sörngård <jsorngard@gmail.com>"]
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["const", "primes"]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -165,18 +165,18 @@ impl<const N: usize> Primes<N> {
     /// // 1024 = 2^10
     /// assert_eq!(CACHE.prime_factorization(1024).next(), Some((2, 10)));
     /// ```
-    /// 42 has 7 as a prime factor, but 7 is not in the cache:
+    /// 294 has 7 as a prime factor, but 7 is not in the cache:
     /// ```
     /// # use const_primes::Primes;
     /// # const CACHE: Primes<3> = Primes::new();
-    /// // 42 = 2*3*7
-    /// let mut factorization_of_42 = CACHE.prime_factorization(42);
+    /// // 294 = 2*3*7*7
+    /// let mut factorization_of_294 = CACHE.prime_factorization(294);
     ///
     /// // only 2 and 3 are in the cache:
-    /// assert_eq!(factorization_of_42.by_ref().collect::<Vec<_>>(), &[(2, 1), (3, 1)]);
+    /// assert_eq!(factorization_of_294.by_ref().collect::<Vec<_>>(), &[(2, 1), (3, 1)]);
     ///
-    /// // the factor of 7 can be found with the remainder function:
-    /// assert_eq!(factorization_of_42.remainder(), Some(7));
+    /// // the factor of 7*7 can be found with the remainder function:
+    /// assert_eq!(factorization_of_294.remainder(), Some(49));
     /// ```
     #[inline]
     pub fn prime_factorization(&self, number: Underlying) -> PrimeFactorization<'_> {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -971,6 +971,27 @@ mod test {
     }
 
     #[test]
+    fn check_prime_factors() {
+        const CACHE: Primes<3> = Primes::new();
+
+        let mut factors_of_14 = CACHE.prime_factors(14);
+
+        assert_eq!(factors_of_14.next(), Some(2));
+        assert_eq!(factors_of_14.next(), None);
+        assert_eq!(factors_of_14.remainder(), Some(7));
+
+        let mut factors_of_15 = CACHE.prime_factors(15);
+
+        assert_eq!(factors_of_15.by_ref().collect::<Vec<_>>(), &[3, 5]);
+        assert!(factors_of_15.remainder().is_none());
+
+        assert_eq!(
+            CACHE.prime_factors(2 * 3 * 3 * 3 * 5).collect::<Vec<_>>(),
+            &[2, 3, 5]
+        );
+    }
+
+    #[test]
     fn check_next_prime() {
         const CACHE: Primes<100> = Primes::new();
         const SPGEQ0: Option<Underlying> = CACHE.next_prime(0);

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -560,7 +560,7 @@ mod prime_factors {
 
     /// An iterator over the prime factors of a given number.
     ///
-    /// Created by the [`factors`](super::Primes::factors)
+    /// Created by the [`prime_factors`](super::Primes::prime_factors)
     /// function on [`Primes`](super::Primes), see it for more information.
     #[derive(Debug, Clone)]
     #[must_use = "iterators are lazy and do nothing unless consumed"]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -207,13 +207,13 @@ impl<const N: usize> Primes<N> {
     /// # use const_primes::Primes;
     /// # const CACHE: Primes<3> = Primes::new();
     /// // 294 = 2*3*7*7
-    /// let mut factors_of_42 = CACHE.prime_factors(294);
+    /// let mut factors_of_294 = CACHE.prime_factors(294);
     ///
     /// // only 2 and 3 are in the cache
-    /// assert_eq!(factors_of_42.by_ref().collect::<Vec<_>>(), &[2, 3]);
+    /// assert_eq!(factors_of_294.by_ref().collect::<Vec<_>>(), &[2, 3]);
     ///
     /// // the factor of 7*7 can be found with the remainder function
-    /// assert_eq!(factors_of_42.remainder(), Some(49));
+    /// assert_eq!(factors_of_294.remainder(), Some(49));
     /// ```
     #[inline]
     pub fn prime_factors(&self, number: Underlying) -> PrimeFactors<'_> {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -591,7 +591,7 @@ mod prime_factors {
             // We haven't actually divided out any of the factors to save work,
             // so we do that by just delegating to PrimeFactorization,
             // which does the work in its implementation of this function.
-            PrimeFactorization::new(&self.primes_cache, self.number).remainder()
+            PrimeFactorization::new(self.primes_cache, self.number).remainder()
         }
     }
 


### PR DESCRIPTION
This PR adds the function `prime_factors` to `Primes<N>` that returns an iterator over the prime factors of a number, but does not determine their multiplicities. This means that it should be faster than `prime_factorization`.

However, in order to determine the remainder after dividing out all factors in the cache, the `remainder` function on this iterator has to do all that work anyway. So it's only sometimes faster.