### PR TITLE
Change the API of `Primes<N>::binary_search` to be the same as `core::slice::binary_search`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 This file contains the changes to the crate since version 0.4.8.
 
+# 0.8.0
+
+## Breaking changes
+
+ - Change `Primes<N>::binary_search` to have the same API as `slice::binary_search`.
+
 # 0.7.2
 
  - Add `Primes<N>::prime_factorization` function that returns an iterator over the prime factors of the given number and their multiplicities.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "const-primes"
 authors = ["Johanna Sörngård <jsorngard@gmail.com>"]
-version = "0.7.2"
+version = "0.8.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["const", "primes"]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -479,6 +479,7 @@ mod prime_factors {
 
         /// If the number contains prime factors that are larger than the largest prime
         /// in the cache, this function returns their product.
+        #[must_use = "`self` will be dropped if the result is not used"]
         pub fn remainder(mut self) -> Option<Underlying> {
             for _ in self.by_ref() {}
             if self.number > 1 {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -807,11 +807,13 @@ mod test {
         const INSERT4: BSResult = CACHE.binary_search(4);
         const FOUND541: BSResult = CACHE.binary_search(541);
         const NOINFO542: BSResult = CACHE.binary_search(542);
+        const BIG: BSResult = CACHE.binary_search(1000000);
         assert_eq!(FOUND2, Ok(0));
         assert_eq!(INSERT0, Err(0));
         assert_eq!(INSERT4, Err(2));
         assert_eq!(FOUND541, Ok(99));
         assert_eq!(NOINFO542, Err(100));
+        assert_eq!(BIG, Err(100));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@
 #![forbid(unsafe_code)]
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 
-/// The type that `Primes<N>` stores, and `primes::<N>()`` returns. Currently `u32`.
+/// The type that `Primes<N>` stores, and `primes::<N>()` returns. Currently `u32`.
 // Just change this to whatever unsigned primitive integer type you want and it should work as long as it has enough bits for your purposes.
 // This is used since there is currently no way to be generic over types that can do arithmetic at compile time.
 type Underlying = u32;


### PR DESCRIPTION
This function unifies the binary search API with the standard library, and edits all functions that internally relied on the non-standard behavior to use the new API.