### PR TITLE
Add a cfg attribute that is available only on docsrs, use it to document feature gates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ std = []
 [package.metadata.docs.rs]
 # Document all features.
 all-features = true
+# Enable the docsrs configuration attribute on docs.rs
+rustdoc-args = ["--cfg", "docsrs"]
 
 [[bench]]
 name = "prime_benches"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,7 @@
 
 #![forbid(unsafe_code)]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 /// The type that `Primes<N>` stores, and `primes::<N>()` returns. Currently `u32`.
 // Just change this to whatever unsigned primitive integer type you want and it should work as long as it has enough bits for your purposes.


### PR DESCRIPTION
This PR adds the `docsrs` configuration attribute that is active when on docs.rs. Check for this attribute in the crate to optionally enable the `doc_auto_cfg` attribute, to document what parts need what features.