### PR TITLE
Add `totient` function to `Primes<N>`

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -882,4 +882,14 @@ mod test {
             assert_eq!(p1, p2);
         }
     }
+
+    #[test]
+    fn check_totient() {
+        const CACHE: Primes<3> = Primes::new();
+        const TOTIENT_OF_6: Result<u32, (u32, u32)> = CACHE.totient(6);
+        const TOTIENT_OF_2450: Result<u32, (u32, u32)> = CACHE.totient(2 * 5 * 5 * 7 * 7);
+
+        assert_eq!(TOTIENT_OF_6, Ok(2));
+        assert_eq!(TOTIENT_OF_2450, Err((20, 49)))
+    }
 }

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -886,10 +886,8 @@ mod test {
     #[test]
     fn check_totient() {
         const CACHE: Primes<3> = Primes::new();
-        const TOTIENT_OF_6: Result<u32, (u32, u32)> = CACHE.totient(6);
-        const TOTIENT_OF_2450: Result<u32, (u32, u32)> = CACHE.totient(2 * 5 * 5 * 7 * 7);
 
-        assert_eq!(TOTIENT_OF_6, Ok(2));
-        assert_eq!(TOTIENT_OF_2450, Err((20, 49)))
+        assert_eq!(CACHE.totient(6), Ok(2));
+        assert_eq!(CACHE.totient(2 * 5 * 5 * 7 * 7), Err((20, 49)))
     }
 }


### PR DESCRIPTION
This PR adds the Euler totient function to the `Primes<N>` type. 

Due to the limitations of a finite cache of primes the implementation returns a `Result::Err` variant if the given number contains prime factors that are not included in the `Primes<N>` instance. This error then contains the partially completed computation.