### PR TITLE
Derive `Serialize` and `Deserialize` for the error types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ This file contains the changes to the crate since version 0.4.8.
 # 0.8.3
 
  - Add the `totient` function to the `Primes` struct.
+ - Derive `Serialize` and `Deserialize` for the error types.
+ - Derive `Hash` for `SieveError`.
 
 # 0.8.2
 

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -11,6 +11,9 @@ pub use primes_iter::PrimesIter;
 
 use crate::{primes, Underlying};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 // region: Primes<N>
 
 /// A wrapper around an array that consists of the first `N` primes. Can use those primes for related computations.
@@ -41,7 +44,7 @@ use crate::{primes, Underlying};
 /// assert_eq!(CACHE.count_primes_leq(1000), None);
 /// ```
 #[derive(Debug, Clone, Copy, Eq, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Primes<const N: usize>(
     #[cfg_attr(feature = "serde", serde(with = "serde_arrays"))] [Underlying; N],
 );
@@ -526,11 +529,12 @@ impl<const N: usize> Primes<N> {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 /// Contains the result of the partial evaluation of the [`totient`](Primes::totient) function.
 ///
 /// It contains the result from computing the totient using only the primes in the related
 /// [`Primes`] struct, and the product of all other remaining prime factors of the given number.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PartialTotient {
     /// The result of computing the totient function with only the primes in the related `Primes` struct.
     pub partial_value: Underlying,

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -391,6 +391,7 @@ pub const fn primes_geq<const N: usize, const MEM: usize>(
 /// Only implements the [`Error`](std::error::Error) trait
 /// if the `std` feature is enabled.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum GenerationError {
     /// The limit was larger than or equal to `MEM^2`.
     TooSmallSieveSize,

--- a/src/sieve.rs
+++ b/src/sieve.rs
@@ -208,7 +208,8 @@ pub const fn sieve<const N: usize>() -> [bool; N] {
 ///
 /// Only implements the [`Error`](std::error::Error) trait
 /// if the `std` feature is enabled.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum SieveError {
     /// The limit was less than or equal to `N` (for `sieve_lt`).
     TooSmallLimit,


### PR DESCRIPTION
This PR adds conditional derivation of the `Serialize` and `Deserialize` traits to `GenerationError` and `SieveError`. It also derives `Hash` for `SieveError`, as I found that was missing.