### PR TITLE
Fix a bug where `primes_lt` and `sieve_lt` could panic if the underlying segmented sieve happend to run down past 0.

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -196,7 +196,7 @@ pub const fn primes_lt<const N: usize, const MEM: usize>(
         // Sieve for primes in the segment.
         let (offset, upper_sieve) = match sieve_segment(&base_sieve, upper_limit) {
             Ok(res) => (0, res),
-            Err(_) => (MEM - upper_limit as usize, base_sieve),
+            Err(_) => ((MEM as u64 - upper_limit) as usize, base_sieve),
         };
 
         let mut i: usize = 0;

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -194,12 +194,15 @@ pub const fn primes_lt<const N: usize, const MEM: usize>(
         // This is the smallest prime we have found so far.
         let mut smallest_found_prime = primes[N - 1 - total_primes_found];
         // Sieve for primes in the segment.
-        let upper_sieve: [bool; MEM] = sieve_segment(&base_sieve, upper_limit);
+        let (offset, upper_sieve) = match sieve_segment(&base_sieve, upper_limit) {
+            Ok(res) => (0, res),
+            Err(_) => (MEM - upper_limit as usize, base_sieve),
+        };
 
         let mut i: usize = 0;
-        while i < MEM {
+        while i < MEM - offset {
             // Iterate backwards through the upper sieve.
-            if upper_sieve[MEM - 1 - i] {
+            if upper_sieve[MEM - 1 - i - offset] {
                 smallest_found_prime = upper_limit - 1 - i as u64;
                 // Write every found prime to the primes array.
                 primes[N - 1 - total_primes_found] = smallest_found_prime;
@@ -368,7 +371,10 @@ pub const fn primes_geq<const N: usize, const MEM: usize>(
     let base_sieve: [bool; MEM] = sieve();
     let mut sieve_limit = lower_limit;
     'generate: while total_found_primes < N {
-        let upper_sieve = sieve_segment(&base_sieve, sieve_limit + mem64);
+        let upper_sieve = match sieve_segment(&base_sieve, sieve_limit + mem64) {
+            Ok(res) => res,
+            Err(_) => panic!("can not happen since we set upper limit to mem + nonzero stuff"),
+        };
 
         let mut i = 0;
         while i < MEM {
@@ -465,7 +471,10 @@ mod test {
         }
         assert_eq!(primes_geq::<0, 0>(10), Ok([]));
         assert_eq!(primes_geq::<3, 3>(2), Ok([2, 3, 5]));
-        assert_eq!(primes_geq::<3, 3>(10), Err(GenerationError::TooSmallSieveSize));
+        assert_eq!(
+            primes_geq::<3, 3>(10),
+            Err(GenerationError::TooSmallSieveSize)
+        );
         assert_eq!(primes_geq::<2, 2>(3), Err(GenerationError::SieveOverrun(4)));
     }
 
@@ -476,7 +485,7 @@ mod test {
             assert_eq!(P, Ok([7, 11, 13, 17, 19]));
         }
         {
-            const P: Result<[u64; 5], GenerationError> = primes_lt::<5,5>(12);
+            const P: Result<[u64; 5], GenerationError> = primes_lt::<5, 5>(12);
             assert_eq!(P, Ok([2, 3, 5, 7, 11]));
         }
         {
@@ -484,7 +493,10 @@ mod test {
             assert_eq!(P, Ok([2]));
         }
         assert_eq!(primes_lt::<2, 2>(2), Err(GenerationError::TooSmallLimit));
-        assert_eq!(primes_lt::<2, 2>(5), Err(GenerationError::TooSmallSieveSize));
+        assert_eq!(
+            primes_lt::<2, 2>(5),
+            Err(GenerationError::TooSmallSieveSize)
+        );
         assert_eq!(primes_lt::<0, 2>(3), Ok([]));
         assert_eq!(primes_lt::<3, 5>(4), Err(GenerationError::OutOfPrimes));
     }

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -463,6 +463,30 @@ mod test {
         for &prime in primes_geq::<2_000, 2_008>(3_998_000).unwrap().as_slice() {
             assert!(is_prime(prime));
         }
+        assert_eq!(primes_geq::<0, 0>(10), Ok([]));
+        assert_eq!(primes_geq::<3, 3>(2), Ok([2, 3, 5]));
+        assert_eq!(primes_geq::<3, 3>(10), Err(GenerationError::TooSmallSieveSize));
+        assert_eq!(primes_geq::<2, 2>(3), Err(GenerationError::SieveOverrun(4)));
+    }
+
+    #[test]
+    fn sanity_check_primes_lt() {
+        {
+            const P: Result<[u64; 5], GenerationError> = primes_lt::<5, 5>(20);
+            assert_eq!(P, Ok([7, 11, 13, 17, 19]));
+        }
+        {
+            const P: Result<[u64; 5], GenerationError> = primes_lt::<5,5>(12);
+            assert_eq!(P, Ok([2, 3, 5, 7, 11]));
+        }
+        {
+            const P: Result<[u64; 1], GenerationError> = primes_lt::<1, 2>(3);
+            assert_eq!(P, Ok([2]));
+        }
+        assert_eq!(primes_lt::<2, 2>(2), Err(GenerationError::TooSmallLimit));
+        assert_eq!(primes_lt::<2, 2>(5), Err(GenerationError::TooSmallSieveSize));
+        assert_eq!(primes_lt::<0, 2>(3), Ok([]));
+        assert_eq!(primes_lt::<3, 5>(4), Err(GenerationError::OutOfPrimes));
     }
 
     #[test]

--- a/src/sieve.rs
+++ b/src/sieve.rs
@@ -5,9 +5,7 @@ use core::fmt;
 use crate::isqrt;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum SegmentedSieveError {
-    TooSmallLimit,
-}
+pub(crate) struct SegmentedSieveError;
 
 /// Uses the primalities of the first `N` integers in `base_sieve` to sieve the numbers in the range `[upper_limit - N, upper_limit)`.
 /// Assumes that the base sieve contains the prime status of the `N` fist integers. The output is only meaningful
@@ -24,7 +22,7 @@ pub(crate) const fn sieve_segment<const N: usize>(
     let mut segment_sieve = [true; N];
 
     let lower_limit = if upper_limit < N as u64 {
-        return Err(SegmentedSieveError::TooSmallLimit);
+        return Err(SegmentedSieveError);
     } else {
         upper_limit - N as u64
     };
@@ -436,7 +434,7 @@ mod test {
         assert_eq!(PP, sieve::<11>()[1..]);
         assert_eq!(
             sieve_segment::<5>(&[false, false, true, true, false], 4),
-            Err(SegmentedSieveError::TooSmallLimit)
+            Err(SegmentedSieveError)
         );
     }
 }

--- a/src/sieve.rs
+++ b/src/sieve.rs
@@ -30,12 +30,10 @@ pub(crate) const fn sieve_segment<const N: usize>(
 ) -> Result<[bool; N], SegmentedSieveError> {
     let mut segment_sieve = [true; N];
 
-    let lower_limit = if upper_limit < N as u64 {
-        return Err(SegmentedSieveError);
-    } else {
-        upper_limit - N as u64
+    let lower_limit = match upper_limit.checked_sub(N as u64) {
+        Some(diff) => diff,
+        None => return Err(SegmentedSieveError),
     };
-    //let lower_limit = upper_limit - N as u64;
 
     if lower_limit == 0 && N > 1 {
         // If the lower limit is 0 we can just return the base sieve.

--- a/src/sieve.rs
+++ b/src/sieve.rs
@@ -418,6 +418,8 @@ macro_rules! sieve_segment {
 
 #[cfg(test)]
 mod test {
+    use crate::sieve::SegmentedSieveError;
+
     use super::{sieve, sieve_segment};
 
     #[test]
@@ -432,5 +434,9 @@ mod test {
         };
         assert_eq!(P, sieve());
         assert_eq!(PP, sieve::<11>()[1..]);
+        assert_eq!(
+            sieve_segment::<5>(&[false, false, true, true, false], 4),
+            Err(SegmentedSieveError::TooSmallLimit)
+        );
     }
 }

--- a/src/sieve.rs
+++ b/src/sieve.rs
@@ -7,6 +7,15 @@ use crate::isqrt;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct SegmentedSieveError;
 
+impl fmt::Display for SegmentedSieveError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "the upper limit was smaller than `N`")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for SegmentedSieveError {}
+
 /// Uses the primalities of the first `N` integers in `base_sieve` to sieve the numbers in the range `[upper_limit - N, upper_limit)`.
 /// Assumes that the base sieve contains the prime status of the `N` fist integers. The output is only meaningful
 /// for the numbers below `N^2`.

--- a/src/sieve.rs
+++ b/src/sieve.rs
@@ -169,7 +169,7 @@ pub const fn sieve_lt<const N: usize, const MEM: usize>(
     let (offset, upper_sieve) = match sieve_segment(&base_sieve, upper_limit) {
         Ok(res) => (0, res),
         // The sieve contained more entries than there are non-negative numbers below the upper limit.
-        Err(_) => (MEM - upper_limit as usize, base_sieve),
+        Err(_) => ((MEM as u64 - upper_limit) as usize, base_sieve),
     };
 
     let mut i = 0;


### PR DESCRIPTION
Now instead we reuse the base sieve, and read from it at an offset.