### PR TITLE
Enable the `const_assert` feature by default

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,7 +62,7 @@ jobs:
       with:
         components: clippy
     - name: clippy_1.67.1
-      run: cargo +1.67.1 clippy --features std,serde -- -D warnings
+      run: cargo +1.67.1 clippy --no-default-features --features std,serde -- -D warnings
 
   coverage:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 This file contains the changes to the crate since version 0.4.8.
 
+# 0.9.0
+
+ - The `const_assert` feature is now enabled by default.
+
 # 0.8.7
 
  - Sped up `is_prime` by checking fewer witnesses in the Miller-Rabin test.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ keywords = ["const", "primes", "no_std", "prime-numbers"]
 categories = ["mathematics", "no-std", "no-std::no-alloc", "algorithms"]
 description = "Work with prime numbers in const contexts. Prime generation, primality testing, prime counting, and more."
 repository = "https://github.com/JSorngard/const-primes/"
-rust-version = "1.67.1"
 
 [dependencies]
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "const-primes"
 authors = ["Johanna Sörngård <jsorngard@gmail.com>"]
-version = "0.8.7"
+version = "0.9.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["const", "primes", "no_std", "prime-numbers"]
@@ -18,6 +18,7 @@ criterion = { version = "0.5", features = ["html_reports"] }
 rand = "0.8"
 
 [features]
+default = ["const_assert"]
 # Implements the `Error` trait from the standard library for the error types.
 std = []
 # Promotes panics that involve only const generics into compile errors. Increases the MSRV of the crate to 1.79.0.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Generate and work with prime numbers in const contexts.
 This crate lets you for example pre-compute prime numbers at compile time, store them in the binary, and use them later for related computations,
 or check whether a number is prime in a const function.
 
-`#![no_std]` compatible, and currently supports Rust versions 1.67.1 or newer, though enabling feature flags may increase this.
+`#![no_std]` compatible, and currently supports Rust versions 1.79.0 or newer, though disabling the `const_assert` feature flag will lower this to 1.67.1.
 
 ## Example: generate primes at compile time and use them for related computations
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! This crate lets you for example pre-compute prime numbers at compile time, store them in the binary, and use them later for related computations,
 //! or check whether a number is prime in a const function.
 //!
-//! `#![no_std]` compatible, and currently supports Rust versions 1.67.1 or newer, though enabling feature flags may increase this.
+//! `#![no_std]` compatible, and currently supports Rust versions 1.79.0 or newer, though disabling the `const_assert` feature flag will lower this to 1.67.1.
 //!
 //! # Example: generate primes at compile time and  reuse it for related computations
 //!


### PR DESCRIPTION
Also notify the users that the feature can be disabled to lower the MSRV.