### PR TITLE
Deserialize a `Primes<N>` by just making a new one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ This file contains the changes to the crate since version 0.4.8.
 
 ## 0.10.4 (unreleased)
 
-- Make serialization of `Primes` just serialize the length.
-- Make deserialization of `Primes` just create a new instance from scratch.
- This is faster since we then do not have to validate that
- every single deserialized integer is prime.
+- Fixed bug that made it possible to deserialize a `Primes` that contained non-primes.
+  - Made serialization of `Primes` just serialize the length.
+  - Made deserialization of `Primes` just create a new instance from scratch.
+    This is faster since we then do not have to validate that
+    every single deserialized integer is prime, which we know to be true due to
+    type invariants.
 - Removed the "no_std" keyword from the crate.
 
 ## 0.10.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ This file contains the changes to the crate since version 0.4.8.
 
 ## 0.10.4 (unreleased)
 
-- Make deserialization of `Primes` fail if not all deserialized numbers are prime.
- It is most likely not worth it to deserialize a `Primes` due to this
- compared to making a new one,
- but this option exists and is now correct!
+- Make serialization of `Primes` just serialize the length.
+- Make deserialization of `Primes` just create a new instance from scratch.
+ This is faster since we then do not have to validate that
+ every single deserialized integer is prime.
 - Removed the "no_std" keyword from the crate.
 
 ## 0.10.3

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -984,5 +984,6 @@ mod test {
         assert!(
             serde_json::from_str::<Primes<3>>("340282366920938463463374607431768211455").is_err()
         );
+        assert!(serde_json::from_str::<Primes<3>>("banana").is_err());
     }
 }

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -69,7 +69,7 @@ impl<const N: usize> serde::Serialize for Primes<N> {
 struct UsizeVisitor;
 
 #[cfg(feature = "serde")]
-impl<'de> serde::de::Visitor<'de> for UsizeVisitor {
+impl serde::de::Visitor<'_> for UsizeVisitor {
     type Value = usize;
 
     fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -981,6 +981,8 @@ mod test {
         assert!(serde_json::from_str::<Primes<3>>("4").is_err());
         assert!(serde_json::from_str::<Primes<3>>("").is_err());
         //                                         u128::MAX
-        assert!(serde_json::from_str::<Primes<3>>("340282366920938463463374607431768211455").is_err());
+        assert!(
+            serde_json::from_str::<Primes<3>>("340282366920938463463374607431768211455").is_err()
+        );
     }
 }


### PR DESCRIPTION
It's faster since we do not need to validate that every single deserialized integer is prime.